### PR TITLE
fix(tests): Mock external API calls to prevent 500 errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ python-multipart
 python-dotenv
 pydantic-settings
 pytest
+pytest-mock
 httpx


### PR DESCRIPTION
The tests were failing in the CI pipeline with a 500 Internal Server Error because they were attempting to make real API calls to the Google Gemini service with a dummy API key.

This change resolves the issue by mocking the external service call.

- Adds `pytest-mock` to `requirements.txt`.
- Updates `tests/test_main.py` to use the `mocker` fixture to patch the `generate_content` method of the Gemini model.
- The mocked method now returns a predictable response, allowing the tests to validate the application's internal logic without network dependencies.